### PR TITLE
Chore: publish to dockerhub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
     branches: [ main ]
   release:
     types: [ published ]
+  workflow_dispatch:
+    inputs:
+      docker_build:
+        description: "Build docker image"
+        type: boolean
+        default: false
+
 
 permissions:
   contents: write
@@ -162,11 +169,11 @@ jobs:
           name: wheel-${{ matrix.target.platform }}
           path: python/dist/*.whl
 
-  # Build and push multi-arch Docker image to GHCR (release only)
+  # Build and push multi-arch Docker image to GHCR (release or manual with docker_build)
   docker:
     name: Docker image
     needs: [build]
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.docker_build == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -221,13 +228,34 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
+      - name: Set tags for manual runs
+        id: tags
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            REF="${{ github.ref_name }}"
+            REF_SANITIZED=$(echo "$REF" | tr '/' '-')
+            SHA=$(git rev-parse --short HEAD)
+            {
+              echo "all_tags<<EOF"
+              echo "${{ steps.meta.outputs.tags }}"
+              echo "manual-${REF_SANITIZED}-${SHA}"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+          else
+            {
+              echo "all_tags<<EOF"
+              echo "${{ steps.meta.outputs.tags }}"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.tags.outputs.all_tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository }}
-            meshyorg/ultar
+            meshyai/ultar
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,15 +230,19 @@ jobs:
 
       - name: Set tags for manual runs
         id: tags
+        env:
+          GH_REPO: ${{ github.repository }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             REF="${{ github.ref_name }}"
             REF_SANITIZED=$(echo "$REF" | tr '/' '-')
             SHA=$(git rev-parse --short HEAD)
+            MANUAL_TAG="manual-${REF_SANITIZED}-${SHA}"
             {
               echo "all_tags<<EOF"
               echo "${{ steps.meta.outputs.tags }}"
-              echo "manual-${REF_SANITIZED}-${SHA}"
+              echo "ghcr.io/${GH_REPO}:${MANUAL_TAG}"
+              echo "meshyai/ultar:${MANUAL_TAG}"
               echo "EOF"
             } >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,11 +203,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: meshyorg
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: |
+            ghcr.io/${{ github.repository }}
+            meshyorg/ultar
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
This adds dockerhub as an image repository for ultar.

Additionally, it allows images to be created on non-release workflows. This should be available in the Actions UI post-merge, and was tested pre-merge via:

```bash
curl -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer $GITHUB_TOKEN" \
  https://api.github.com/repos/meshy-dev/ultar/actions/workflows/ci.yml/dispatches \
  -d '{"ref":"chore-push-to-dockerhub","inputs":{"docker_build":"true"}}'
```